### PR TITLE
Initial session creation support (and MockHSM to test against)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rust:
 script:
   - rustc --version --verbose
   - cargo --version --verbose
-  - cargo build
+  - cargo test --features mockhsm
 
 branches:
   only:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,13 @@ categories  = ["cryptography"]
 keywords    = ["cryptography", "encryption", "security"]
 
 [dependencies]
-scp03 = { path = "scp03" }
+byteorder = "1.2"
 failure = "0.1"
-failure_derive = "*"
+failure_derive = "0.1"
+scp03 = { path = "scp03" }
 reqwest = "0.8"
+tiny_http = { version = "0.5", optional = true }
+
+[features]
+default = []
+mockhsm = ["tiny_http"]

--- a/scp03/src/identity.rs
+++ b/scp03/src/identity.rs
@@ -8,7 +8,6 @@ use sha2::Sha256;
 use super::KEY_SIZE;
 
 /// Static identity keys from which session keys are derived
-#[allow(dead_code)]
 pub struct IdentityKeys {
     // Static encryption key (K-ENC)
     pub(crate) enc_key: [u8; KEY_SIZE],

--- a/scp03/src/lib.rs
+++ b/scp03/src/lib.rs
@@ -28,7 +28,7 @@ mod session;
 /// AES key size in bytes
 pub const KEY_SIZE: usize = 16;
 
-pub use challenge::Challenge;
+pub use challenge::{Challenge, CHALLENGE_SIZE};
 pub use context::Context;
 pub use cryptogram::Cryptogram;
 pub use identity::IdentityKeys;

--- a/scp03/src/session.rs
+++ b/scp03/src/session.rs
@@ -8,7 +8,6 @@ use identity::IdentityKeys;
 use super::KEY_SIZE;
 
 /// Session keys as derived from per-session challenges
-#[allow(dead_code)]
 pub struct SessionKeys {
     // Session encryption key (S-ENC)
     enc_key: [u8; KEY_SIZE],

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,267 @@
+//! Commands sent to/from the YubiHSM2
+
+use byteorder::{BigEndian, ByteOrder};
+use failure::Error;
+
+/// Command IDs for YubiHSM2 operations
+#[allow(dead_code, missing_docs)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CommandType {
+    Unknown = 0x00,
+    Echo = 0x01,
+    CreateSession = 0x03,
+    AuthSession = 0x04,
+    SessionMessage = 0x05,
+    GetDeviceInfo = 0x06,
+    BSL = 0x07,
+    Reset = 0x08,
+    CloseSession = 0x40,
+    Stats = 0x41,
+    PutOpaqueObject = 0x42,
+    GetOpaqueObject = 0x43,
+    PutAuthKey = 0x44,
+    PutAsymmetricKey = 0x45,
+    GenAsymmetricKey = 0x46,
+    SignDataPKCS1 = 0x47,
+    ListObjects = 0x48,
+    DecryptPKCS1 = 0x49,
+    ExportWrapped = 0x4a,
+    ImportWrapped = 0x4b,
+    PutWrapKey = 0x4c,
+    GetLogs = 0x4d,
+    GetObjectInfo = 0x4e,
+    PutOption = 0x4f,
+    GetOption = 0x50,
+    GetPseudoRandom = 0x51,
+    PutHMACKey = 0x52,
+    HMACData = 0x53,
+    GetPubKey = 0x54,
+    SignDataPSS = 0x55,
+    SignDataECDSA = 0x56,
+    DecryptECDH = 0x57,
+    DeleteObject = 0x58,
+    DecryptOAEP = 0x59,
+    GenerateHMACKey = 0x5a,
+    GenerateWrapKey = 0x5b,
+    VerifyHMAC = 0x5c,
+    SSHCertify = 0x5d,
+    PutTemplate = 0x5e,
+    GetTemplate = 0x5f,
+    DecryptOTP = 0x60,
+    CreateOTPAEAD = 0x61,
+    RandomOTPAEAD = 0x62,
+    RewrapOTPAEAD = 0x63,
+    AttestAsymmetric = 0x64,
+    PutOTPAEAD = 0x65,
+    GenerateOTPAEAD = 0x66,
+    SetLogIndex = 0x67,
+    WrapData = 0x68,
+    UnwrapData = 0x69,
+    SignDataEdDSA = 0x6a,
+    Blink = 0x6b,
+    Error = 0x7f,
+}
+
+impl CommandType {
+    /// Convert an unsigned byte into a CommandType (if valid)
+    pub fn from_byte(byte: u8) -> Result<Self, Error> {
+        Ok(match byte {
+            0x00 => CommandType::Unknown,
+            0x01 => CommandType::Echo,
+            0x03 => CommandType::CreateSession,
+            0x04 => CommandType::AuthSession,
+            0x05 => CommandType::SessionMessage,
+            0x06 => CommandType::GetDeviceInfo,
+            0x07 => CommandType::BSL,
+            0x08 => CommandType::Reset,
+            0x40 => CommandType::CloseSession,
+            0x41 => CommandType::Stats,
+            0x42 => CommandType::PutOpaqueObject,
+            0x43 => CommandType::GetOpaqueObject,
+            0x44 => CommandType::PutAuthKey,
+            0x45 => CommandType::PutAsymmetricKey,
+            0x46 => CommandType::GenAsymmetricKey,
+            0x47 => CommandType::SignDataPKCS1,
+            0x48 => CommandType::ListObjects,
+            0x49 => CommandType::DecryptPKCS1,
+            0x4a => CommandType::ExportWrapped,
+            0x4b => CommandType::ImportWrapped,
+            0x4c => CommandType::PutWrapKey,
+            0x4d => CommandType::GetLogs,
+            0x4e => CommandType::GetObjectInfo,
+            0x4f => CommandType::PutOption,
+            0x50 => CommandType::GetOption,
+            0x51 => CommandType::GetPseudoRandom,
+            0x52 => CommandType::PutHMACKey,
+            0x53 => CommandType::HMACData,
+            0x54 => CommandType::GetPubKey,
+            0x55 => CommandType::SignDataPSS,
+            0x56 => CommandType::SignDataECDSA,
+            0x57 => CommandType::DecryptECDH,
+            0x58 => CommandType::DeleteObject,
+            0x59 => CommandType::DecryptOAEP,
+            0x5a => CommandType::GenerateHMACKey,
+            0x5b => CommandType::GenerateWrapKey,
+            0x5c => CommandType::VerifyHMAC,
+            0x5d => CommandType::SSHCertify,
+            0x5e => CommandType::PutTemplate,
+            0x5f => CommandType::GetTemplate,
+            0x60 => CommandType::DecryptOTP,
+            0x61 => CommandType::CreateOTPAEAD,
+            0x62 => CommandType::RandomOTPAEAD,
+            0x63 => CommandType::RewrapOTPAEAD,
+            0x64 => CommandType::AttestAsymmetric,
+            0x65 => CommandType::PutOTPAEAD,
+            0x66 => CommandType::GenerateOTPAEAD,
+            0x67 => CommandType::SetLogIndex,
+            0x68 => CommandType::WrapData,
+            0x69 => CommandType::UnwrapData,
+            0x6a => CommandType::SignDataEdDSA,
+            0x6b => CommandType::Blink,
+            0x7f => CommandType::Error,
+            _ => bail!("invalid response code: {}", byte),
+        })
+    }
+}
+
+/// Command responses
+#[derive(Debug, Eq, PartialEq)]
+pub struct Response {
+    code: ResponseCode,
+    body: Vec<u8>,
+}
+
+impl Response {
+    /// Parse a response into a response struct
+    pub fn parse(mut bytes: Vec<u8>) -> Result<Self, Error> {
+        if bytes.len() < 3 {
+            bail!("response too short: {}", bytes.len())
+        }
+
+        let code = ResponseCode::from_byte(bytes[0])?;
+
+        // Check that the length is valid
+        let length = BigEndian::read_u16(&bytes[1..3]) as usize;
+        if length + 3 != bytes.len() {
+            bail!(
+                "unexpected response length {} (expecting {})",
+                bytes.len() - 3,
+                length
+            );
+        }
+
+        bytes.drain(..3);
+        Ok(Response { code, body: bytes })
+    }
+
+    /// Was this command successful?
+    pub fn is_ok(&self) -> bool {
+        match self.code {
+            ResponseCode::Success(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Did an error occur?
+    pub fn is_err(&self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Get the command being responded to
+    pub fn command(&self) -> Option<CommandType> {
+        match self.code {
+            ResponseCode::Success(cmd) => Some(cmd),
+            _ => None,
+        }
+    }
+
+    /// Get the code for this response
+    pub fn code(&self) -> ResponseCode {
+        self.code
+    }
+
+    /// Get the body of this response
+    pub fn body(&self) -> &[u8] {
+        &self.body
+    }
+}
+
+/// Codes associated with YubiHSM2 responses
+#[allow(dead_code, missing_docs)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ResponseCode {
+    Success(CommandType),
+    MemoryError,
+    InitError,
+    NetError,
+    ConnectorNotFound,
+    InvalidParams,
+    WrongLength,
+    BufferTooSmall,
+    CryptogramMismatch,
+    AuthSessionError,
+    MACMismatch,
+    DeviceOK,
+    DeviceInvalidCommand,
+    DeviceInvalidData,
+    DeviceInvalidSession,
+    DeviceAuthFail,
+    DeviceSessionsFull,
+    DeviceSessionFailed,
+    DeviceStorageFailed,
+    DeviceWrongLength,
+    DeviceInvalidPermission,
+    DeviceLogFull,
+    DeviceObjNotFound,
+    DeviceIDIllegal,
+    DeviceInvalidOTP,
+    DeviceDemoMode,
+    DeviceCmdUnexecuted,
+    GenericError,
+    DeviceObjectExists,
+    ConnectorError,
+}
+
+impl ResponseCode {
+    /// Convert an unsigned byte into a ResponseCode (if valid)
+    pub fn from_byte(byte: u8) -> Result<Self, Error> {
+        Ok(match byte {
+            127 => ResponseCode::MemoryError,
+            126 => ResponseCode::InitError,
+            125 => ResponseCode::NetError,
+            124 => ResponseCode::ConnectorNotFound,
+            123 => ResponseCode::InvalidParams,
+            122 => ResponseCode::WrongLength,
+            121 => ResponseCode::BufferTooSmall,
+            120 => ResponseCode::CryptogramMismatch,
+            119 => ResponseCode::AuthSessionError,
+            118 => ResponseCode::MACMismatch,
+            117 => ResponseCode::DeviceOK,
+            116 => ResponseCode::DeviceInvalidCommand,
+            115 => ResponseCode::DeviceInvalidData,
+            114 => ResponseCode::DeviceInvalidSession,
+            113 => ResponseCode::DeviceAuthFail,
+            112 => ResponseCode::DeviceSessionsFull,
+            111 => ResponseCode::DeviceSessionFailed,
+            110 => ResponseCode::DeviceStorageFailed,
+            109 => ResponseCode::DeviceWrongLength,
+            108 => ResponseCode::DeviceInvalidPermission,
+            107 => ResponseCode::DeviceLogFull,
+            106 => ResponseCode::DeviceObjNotFound,
+            105 => ResponseCode::DeviceIDIllegal,
+            104 => ResponseCode::DeviceInvalidOTP,
+            103 => ResponseCode::DeviceDemoMode,
+            102 => ResponseCode::DeviceCmdUnexecuted,
+            101 => ResponseCode::GenericError,
+            100 => ResponseCode::DeviceObjectExists,
+            99 => ResponseCode::ConnectorError,
+            _ => {
+                if byte > 127 {
+                    ResponseCode::Success(CommandType::from_byte(byte - 128)?)
+                } else {
+                    bail!("invalid response code: {}", 128 - byte)
+                }
+            }
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,25 @@
 //! yubihsm-client: client for YubiHSM2 hardware security modules
 
 #![crate_name = "yubihsm_client"]
-#![crate_type = "lib"]
+#![crate_type = "bin"]
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 
+extern crate byteorder;
+#[macro_use]
 extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 extern crate reqwest;
 extern crate scp03;
 
-#[macro_use]
-extern crate failure_derive;
-
+pub(crate) mod command;
 pub mod connector;
+#[cfg(any(feature = "mockhsm"))]
+pub mod mockhsm;
+pub mod session;
 
 pub use connector::Connector;
+
+/// Key identifiers
+pub type KeyID = u16;

--- a/src/mockhsm.rs
+++ b/src/mockhsm.rs
@@ -1,0 +1,169 @@
+//! Software simulation of the YubiHSM2 for integration testing
+//!
+//! To enable, make sure to build yubihsm-client with the "mockhsm" feature
+
+extern crate tiny_http;
+
+use self::tiny_http::{Method, Request, Response, Server, StatusCode};
+
+use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
+use failure::Error;
+use std::io::Cursor;
+
+use command::CommandType;
+use connector::{PBKDF2_ITERATIONS, PBKDF2_SALT};
+use scp03::{Challenge, Context, IdentityKeys, SessionKeys, CHALLENGE_SIZE};
+use super::KeyID;
+
+/// Default auth key ID slot
+const DEFAULT_AUTH_KEY_ID: KeyID = 1;
+
+/// Default password
+const DEFAULT_PASSWORD: &str = "password";
+
+/// Software simulation of a YubiHSM2 intended for testing
+pub struct MockHSM {
+    addr: String,
+    server: Server,
+    static_keys: IdentityKeys,
+}
+
+impl MockHSM {
+    /// Create a new MockHSM. This will bind to the given address/port but will
+    /// not start processing requests until the `run` method is invoked
+    pub fn new(addr: &str) -> Result<Self, Error> {
+        let server = Server::http(addr)
+            .or_else(|e| Err(format_err!("error creating MockHSM server: {:?}", e)))?;
+        Ok(Self {
+            addr: addr.to_owned(),
+            server,
+            static_keys: IdentityKeys::derive_from_password(
+                DEFAULT_PASSWORD.as_bytes(),
+                PBKDF2_SALT,
+                PBKDF2_ITERATIONS,
+            ),
+        })
+    }
+
+    /// Run the MockHSM server, processing the given number of requests and then stopping
+    pub fn run(&self, num_requests: usize) {
+        for (i, mut request) in self.server.incoming_requests().enumerate() {
+            //println!(
+            //    "received request! method: {:?}, url: {:?}, headers: {:?}",
+            //    request.method(),
+            //    request.url(),
+            //    request.headers()
+            //);
+
+            let response = match *request.method() {
+                Method::Get => match request.url() {
+                    "/connector/status" => Some(self.status()),
+                    _ => None,
+                },
+                Method::Post => match request.url() {
+                    "/connector/api" => Some(self.api(&mut request)),
+                    _ => None,
+                },
+                _ => None,
+            }.unwrap_or_else(|| {
+                Response::new(
+                    StatusCode::from(404),
+                    vec![],
+                    Cursor::new(vec![]),
+                    None,
+                    None,
+                )
+            });
+
+            request.respond(response).unwrap();
+
+            if i + 1 >= num_requests {
+                break;
+            }
+        }
+    }
+
+    /// GET /connector/status - status page
+    fn status(&self) -> Response<Cursor<Vec<u8>>> {
+        let mut addr_parts = self.addr.split(":");
+
+        Response::from_string(
+            [
+                "status=OK",
+                "serial=*",
+                "version=1.0.1",
+                "pid=12345",
+                &format!("address={}", addr_parts.next().unwrap()),
+                &format!("port={}", addr_parts.next().unwrap()),
+            ].join("\n"),
+        )
+    }
+
+    /// POST /connector/api - perform HSM operation
+    fn api(&self, request: &mut Request) -> Response<Cursor<Vec<u8>>> {
+        let mut body = Vec::new();
+        request
+            .as_reader()
+            .read_to_end(&mut body)
+            .expect("HTTP request read error");
+
+        let length = BigEndian::read_u16(&body[1..3]);
+        if (length + 3) as usize != body.len() {
+            panic!(
+                "unexpected HSM command length: {} (expected {})",
+                body.len() - 3,
+                length
+            );
+        }
+
+        let payload = &body[3..];
+
+        match CommandType::from_byte(body[0]).unwrap() {
+            CommandType::CreateSession => self.create_session(payload),
+            unsupported => panic!("unsupported command type: {:?}", unsupported),
+        }
+    }
+
+    /// Create a new HSM session
+    fn create_session(&self, payload: &[u8]) -> Response<Cursor<Vec<u8>>> {
+        if payload.len() != 10 {
+            panic!(
+                "create_session: unexpected payload length {} (expected 10)",
+                payload.len()
+            );
+        }
+
+        let auth_key_id = BigEndian::read_u16(&payload[..2]);
+        assert_eq!(
+            auth_key_id, DEFAULT_AUTH_KEY_ID,
+            "unexpected auth key ID: {}",
+            auth_key_id
+        );
+
+        let host_challenge = Challenge::from_slice(&payload[2..]);
+        let card_challenge = Challenge::random();
+        let context = Context::from_challenges(&host_challenge, &card_challenge);
+        let session_keys = SessionKeys::derive(&self.static_keys, &context);
+        let card_cryptogram = session_keys.card_cryptogram(&context);
+
+        // TODO: don't hardcode this
+        let session_id = 0u8;
+
+        let mut response_body = Vec::with_capacity(1 + CHALLENGE_SIZE * 2);
+        response_body.push(session_id);
+        response_body.extend_from_slice(card_challenge.as_slice());
+        response_body.extend_from_slice(card_cryptogram.as_slice());
+
+        respond_success(CommandType::CreateSession, &response_body)
+    }
+}
+
+/// Create a response for a successful request
+fn respond_success(cmd: CommandType, payload: &[u8]) -> Response<Cursor<Vec<u8>>> {
+    let mut body = Vec::with_capacity(3 + payload.len());
+    body.push(cmd as u8 + 128);
+    body.write_u16::<BigEndian>(payload.len() as u16).unwrap();
+    body.extend_from_slice(payload);
+
+    Response::from_data(body)
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,117 @@
+//! YubiHSM2 sessions: primary API for performing HSM operations
+//!
+//! See <https://developers.yubico.com/YubiHSM2/Concepts/Session.html>
+
+use byteorder::{BigEndian, WriteBytesExt};
+use command::CommandType;
+use connector::Connector;
+use failure::Error;
+use scp03::{Challenge, Context, Cryptogram, IdentityKeys, SessionKeys, CHALLENGE_SIZE};
+use super::KeyID;
+
+/// Maximum session identifier
+const MAX_SESSION_ID: u8 = 16;
+
+/// Encrypted session with the YubiHSM2
+// TODO: don't allow dead code
+#[allow(dead_code)]
+pub struct Session<'a> {
+    connector: &'a Connector,
+    id: SessionID,
+    keys: SessionKeys,
+}
+
+/// Session-related errors
+#[derive(Debug, Fail)]
+pub enum SessionError {
+    /// Couldn't create session
+    #[fail(display = "couldn't create session: {}", description)]
+    CreateFailed {
+        /// Description of why we couldn't create the session
+        description: String,
+    },
+
+    /// Couldn't authenticate session
+    #[fail(display = "authentication failed: {}", description)]
+    AuthenticationFailed {
+        /// Details about the authentication failure
+        description: String,
+    },
+}
+
+impl<'a> Session<'a> {
+    /// Create a new encrypted session using the given auth key and password
+    pub fn new(
+        connector: &'a Connector,
+        host_challenge: &Challenge,
+        auth_key_id: KeyID,
+        static_keys: IdentityKeys,
+    ) -> Result<Self, Error> {
+        let mut payload = Vec::with_capacity(10);
+        payload.write_u16::<BigEndian>(auth_key_id)?;
+        payload.extend_from_slice(host_challenge.as_slice());
+
+        let response = connector.command(CommandType::CreateSession, payload)?;
+
+        if response.is_err() {
+            Err(SessionError::CreateFailed {
+                description: format!("HSM error: {:?}", response.code()),
+            })?;
+        }
+
+        if response.command().unwrap() != CommandType::CreateSession {
+            Err(SessionError::CreateFailed {
+                description: format!(
+                    "invalid response length {} (expected {})",
+                    response.body().len(),
+                    1 + CHALLENGE_SIZE * 2
+                ),
+            })?;
+        }
+
+        let response_body = response.body();
+        if response_body.len() != 1 + CHALLENGE_SIZE * 2 {
+            Err(SessionError::CreateFailed {
+                description: format!("command type mismatch: {:?}", response.command().unwrap()),
+            })?;
+        }
+
+        let session_id = SessionID::new(response_body[0])?;
+        let card_challenge = Challenge::from_slice(&response_body[1..9]);
+        let context = Context::from_challenges(&host_challenge, &card_challenge);
+        let session_keys = SessionKeys::derive(&static_keys, &context);
+        let expected_card_cryptogram = session_keys.card_cryptogram(&context);
+        let actual_card_cryptogram = Cryptogram::from_slice(&response_body[9..17]);
+
+        if expected_card_cryptogram != actual_card_cryptogram {
+            Err(SessionError::AuthenticationFailed {
+                description: "card cryptogram verification failed!".to_owned(),
+            })?;
+        }
+
+        Ok(Self {
+            connector,
+            id: session_id,
+            keys: session_keys,
+        })
+    }
+
+    /// Get the current session ID
+    pub fn id(&self) -> SessionID {
+        self.id
+    }
+}
+
+/// Session IDs
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SessionID(pub u8);
+
+impl SessionID {
+    fn new(id: u8) -> Result<Self, Error> {
+        if id > MAX_SESSION_ID {
+            bail!("session ID exceeds the maximum allowed")
+        }
+
+        Ok(SessionID(id))
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,34 @@
+extern crate yubihsm_client;
+
+use std::thread;
+
+use yubihsm_client::{Connector, KeyID};
+use yubihsm_client::mockhsm::MockHSM;
+
+// TODO: pick an open port automatically
+const MOCKHSM_ADDR: &str = "127.0.0.1:54321";
+
+/// Default auth key ID slot
+const DEFAULT_AUTH_KEY_ID: KeyID = 1;
+
+/// Default password
+const DEFAULT_PASSWORD: &str = "password";
+
+fn start_mockhsm(num_requests: usize) -> thread::JoinHandle<()> {
+    thread::spawn(move || MockHSM::new(MOCKHSM_ADDR).unwrap().run(num_requests))
+}
+
+#[test]
+fn mockhsm_integration_test() {
+    let mockhsm_thread = start_mockhsm(2);
+
+    let conn = Connector::open(&format!("http://{}", MOCKHSM_ADDR))
+        .unwrap_or_else(|err| panic!("cannot open connection to yubihsm-connector: {:?}", err));
+
+    let session = conn.create_session_from_password(DEFAULT_AUTH_KEY_ID, DEFAULT_PASSWORD)
+        .unwrap_or_else(|err| panic!("error creating session: {:?}", err));
+
+    assert_eq!(session.id().0, 0);
+
+    mockhsm_thread.join().unwrap();
+}


### PR DESCRIPTION
Adds support for creating SCP03 sessions with the YubiHSM2.

Additionally adds a mock reimplementation of the YubiHSM2 for testing purposes, called "MockHSM"