### PR TITLE
Initial scp03 crate: GlobalPlatform Secure Channel Protocol '03'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target
+target
 **/*.rs.bk
 Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: rust
 
 rust:
-  - stable
-  - beta
+# TODO: test on stable/beta when aesni crate works with stdsimd
+#  - stable
+#  - beta
   - nightly
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories  = ["cryptography"]
 keywords    = ["cryptography", "encryption", "security"]
 
 [dependencies]
+scp03 = { path = "scp03" }
 failure = "0.1"
 failure_derive = "*"
 reqwest = "0.8"

--- a/scp03/Cargo.toml
+++ b/scp03/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name        = "scp03"
+description = "GlobalPlatform Secure Channel Protocol 03 implementation targeting YubiHSM2 devices"
+version     = "0.0.0"
+authors     = ["Tony Arcieri <bascule@gmail.com>"]
+license     = "MIT/Apache-2.0"
+homepage    = "https://github.com/tarcieri/yubihsm-client"
+readme      = "README.md"
+categories  = ["cryptography"]
+keywords    = ["cryptography", "encryption", "security"]
+
+[dependencies]
+aesni = "0.2"
+byteorder = { version = "1.2", default_features = false }
+clear_on_drop = "0.2"
+cmac = "0.1"
+constant_time_eq = "0.1"
+hmac = "0.4"
+pbkdf2 = "0.1"
+rand = "0.4"
+sha2 = "0.6"

--- a/scp03/README.md
+++ b/scp03/README.md
@@ -1,0 +1,14 @@
+# scp03.rs
+
+A Rust implementation of the [GlobalPlatform] Secure Channel Protocol "03"
+intended for use [YubiHSM2] devices from [Yubico].
+
+The protocol is documented in
+"GPC_SPE_014: GlobalPlatform Card Technology Secure Channel Protocol 03"
+available at:
+
+https://www.globalplatform.org/specificationscard.asp
+
+[GlobalPlatform]: https://www.globalplatform.org/
+[YubiHSM2]: https://www.yubico.com/products/yubihsm/
+[Yubico]: https://www.yubico.com/

--- a/scp03/src/challenge.rs
+++ b/scp03/src/challenge.rs
@@ -1,0 +1,37 @@
+use rand::{OsRng, Rng};
+
+/// Size of a challenge message
+pub const CHALLENGE_SIZE: usize = 8;
+
+/// A challenge message, sent by either host or the card
+pub struct Challenge([u8; CHALLENGE_SIZE]);
+
+impl Challenge {
+    /// Generate a random Challenge using OsRng
+    pub fn random() -> Self {
+        Self::new(&mut OsRng::new().expect("RNG failure!"))
+    }
+
+    /// Create a new Challenge using the given RNG
+    pub fn new(rng: &mut Rng) -> Self {
+        let mut challenge = [0u8; CHALLENGE_SIZE];
+        rng.fill_bytes(&mut challenge);
+        Challenge(challenge)
+    }
+
+    /// Create a new challenge from a slice
+    ///
+    /// Panics if the slice is not 8-bytes
+    pub fn from_slice(slice: &[u8]) -> Self {
+        assert_eq!(slice.len(), 8, "challenge must be 8-bytes long");
+
+        let mut challenge = [0u8; CHALLENGE_SIZE];
+        challenge.copy_from_slice(slice);
+        Challenge(challenge)
+    }
+
+    /// Borrow the challenge value as a slice
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/scp03/src/context.rs
+++ b/scp03/src/context.rs
@@ -1,0 +1,21 @@
+//! Derivation context (i.e. concatenated challenges)
+
+use challenge::{Challenge, CHALLENGE_SIZE};
+
+/// Derivation context (i.e. concatenated challenges)
+pub struct Context([u8; CHALLENGE_SIZE * 2]);
+
+impl Context {
+    /// Create a derivation context from host and card challenges
+    pub fn from_challenges(host_challenge: &Challenge, card_challenge: &Challenge) -> Self {
+        let mut context = [0u8; CHALLENGE_SIZE * 2];
+        context[..CHALLENGE_SIZE].copy_from_slice(host_challenge.as_slice());
+        context[CHALLENGE_SIZE..].copy_from_slice(card_challenge.as_slice());
+        Context(context)
+    }
+
+    /// Borrow the context value as a slice
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/scp03/src/cryptogram.rs
+++ b/scp03/src/cryptogram.rs
@@ -1,0 +1,84 @@
+//! Authentication cryptograms (8-byte MACs) used for session verification
+
+use aesni::Aes128;
+use byteorder::{BigEndian, ByteOrder};
+use clear_on_drop::clear::Clear;
+use constant_time_eq::constant_time_eq;
+use cmac::Cmac;
+use cmac::crypto_mac::Mac;
+
+use challenge::CHALLENGE_SIZE;
+use context::Context;
+use super::KEY_SIZE;
+
+/// Authentication cryptograms used to verify sessions
+#[derive(Eq)]
+pub struct Cryptogram([u8; CHALLENGE_SIZE]);
+
+impl Cryptogram {
+    /// Create a new cryptogram from a slice
+    ///
+    /// Panics if the slice is not 8-bytes
+    pub fn from_slice(slice: &[u8]) -> Self {
+        assert_eq!(slice.len(), 8, "cryptogram must be 8-bytes long");
+
+        let mut cryptogram = [0u8; CHALLENGE_SIZE];
+        cryptogram.copy_from_slice(slice);
+        Cryptogram(cryptogram)
+    }
+
+    /// Borrow the cryptogram value as a slice
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl PartialEq for Cryptogram {
+    fn eq(&self, other: &Cryptogram) -> bool {
+        constant_time_eq(&self.0[..], &other.0[..])
+    }
+}
+
+impl Drop for Cryptogram {
+    fn drop(&mut self) {
+        self.0.clear();
+    }
+}
+
+/// Calculate an SCP03 cryptogram of arbitrary size
+pub(crate) fn calculate(
+    mac_key: &[u8; KEY_SIZE],
+    derivation_constant: u8,
+    context: &Context,
+    output: &mut [u8],
+) {
+    let output_len = output.len();
+    assert!(
+        output_len <= 16,
+        "up to 16-bytes of data supported ({} requested)",
+        output_len
+    );
+
+    let mut derivation_data = [0u8; 32];
+
+    // "label": 11-bytes of '0' followed by 1-byte derivation constant
+    // See Table 4-1: Data Derivation Constants in GPC_SPE_014
+    derivation_data[11] = derivation_constant;
+
+    // "separation indicator": 1-byte '0'
+    derivation_data[12] = 0x00;
+
+    // "L": length of derived data in bits
+    BigEndian::write_u16(&mut derivation_data[13..15], (output_len * 8) as u16);
+
+    // "i": KDF counter for deriving more than one block-length of data
+    // Hardcoded to 1 as we don't support deriving more than 128-bits
+    derivation_data[15] = 0x01;
+
+    // Derivation context (i.e. challenges concatenated)
+    derivation_data[16..].copy_from_slice(context.as_slice());
+
+    let mut mac = Cmac::<Aes128>::new_varkey(&mac_key[..]).unwrap();
+    mac.input(&derivation_data);
+    output.copy_from_slice(&mac.result().code().as_slice()[..output_len]);
+}

--- a/scp03/src/identity.rs
+++ b/scp03/src/identity.rs
@@ -1,0 +1,49 @@
+//! Static key operations for proving identity
+
+use clear_on_drop::clear::Clear;
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use sha2::Sha256;
+
+use super::KEY_SIZE;
+
+/// Static identity keys from which session keys are derived
+#[allow(dead_code)]
+pub struct IdentityKeys {
+    // Static encryption key (K-ENC)
+    pub(crate) enc_key: [u8; KEY_SIZE],
+
+    // Static MAC key (K-MAC)
+    pub(crate) mac_key: [u8; KEY_SIZE],
+}
+
+impl IdentityKeys {
+    /// Derive identity keys from a password
+    pub fn derive_from_password(password: &[u8], salt: &[u8], iterations: usize) -> Self {
+        let mut kdf_output = [0u8; KEY_SIZE * 2];
+        pbkdf2::<Hmac<Sha256>>(password, salt, iterations, &mut kdf_output);
+
+        let keys = Self::new(&kdf_output);
+        kdf_output.clear();
+
+        keys
+    }
+
+    /// Create a new keypair from a byte array
+    pub fn new(key_bytes: &[u8; KEY_SIZE * 2]) -> Self {
+        let mut enc_key = [0u8; KEY_SIZE];
+        enc_key.copy_from_slice(&key_bytes[..KEY_SIZE]);
+
+        let mut mac_key = [0u8; KEY_SIZE];
+        mac_key.copy_from_slice(&key_bytes[KEY_SIZE..]);
+
+        Self { enc_key, mac_key }
+    }
+}
+
+impl Drop for IdentityKeys {
+    fn drop(&mut self) {
+        self.enc_key.clear();
+        self.mac_key.clear();
+    }
+}

--- a/scp03/src/lib.rs
+++ b/scp03/src/lib.rs
@@ -1,0 +1,35 @@
+//! Implementation of the GlobalPlatform Secure Channel Protocol "03" used by YubiHSM2
+//!
+//! See GPC_SPE_014: GlobalPlatform Card Technology Secure Channel Protocol '03' at:
+//! <https://www.globalplatform.org/specificationscard.asp>
+
+#![crate_name = "scp03"]
+#![crate_type = "lib"]
+#![no_std]
+#![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
+#![deny(unsafe_code, unused_import_braces, unused_qualifications)]
+
+extern crate aesni;
+extern crate byteorder;
+extern crate clear_on_drop;
+extern crate cmac;
+extern crate constant_time_eq;
+extern crate hmac;
+extern crate pbkdf2;
+extern crate rand;
+extern crate sha2;
+
+mod challenge;
+mod context;
+mod cryptogram;
+mod identity;
+mod session;
+
+/// AES key size in bytes
+pub const KEY_SIZE: usize = 16;
+
+pub use challenge::Challenge;
+pub use context::Context;
+pub use cryptogram::Cryptogram;
+pub use identity::IdentityKeys;
+pub use session::SessionKeys;

--- a/scp03/src/session.rs
+++ b/scp03/src/session.rs
@@ -1,0 +1,66 @@
+//! Cryptographic sessions within the SCP03 protocol
+
+use challenge::CHALLENGE_SIZE;
+use context::Context;
+use clear_on_drop::clear::Clear;
+use cryptogram::{self, Cryptogram};
+use identity::IdentityKeys;
+use super::KEY_SIZE;
+
+/// Session keys as derived from per-session challenges
+#[allow(dead_code)]
+pub struct SessionKeys {
+    // Session encryption key (S-ENC)
+    enc_key: [u8; KEY_SIZE],
+
+    // Session Command MAC key (S-MAC)
+    mac_key: [u8; KEY_SIZE],
+
+    // Session Respose MAC key (S-RMAC)
+    rmac_key: [u8; KEY_SIZE],
+}
+
+impl SessionKeys {
+    /// Derive session keys from static identity keys and host/card challenges
+    pub fn derive(static_keys: &IdentityKeys, context: &Context) -> Self {
+        let enc_key = derive_key(&static_keys.enc_key, 0b100, &context);
+        let mac_key = derive_key(&static_keys.mac_key, 0b110, &context);
+        let rmac_key = derive_key(&static_keys.mac_key, 0b111, &context);
+
+        Self {
+            enc_key,
+            mac_key,
+            rmac_key,
+        }
+    }
+
+    /// Obtain the card cryptogram for this session
+    pub fn card_cryptogram(&self, context: &Context) -> Cryptogram {
+        let mut result_slice = [0u8; CHALLENGE_SIZE];
+        cryptogram::calculate(&self.mac_key, 0, context, &mut result_slice);
+
+        let result = Cryptogram::from_slice(&result_slice);
+        result_slice.clear();
+
+        result
+    }
+}
+
+impl Drop for SessionKeys {
+    fn drop(&mut self) {
+        self.enc_key.clear();
+        self.mac_key.clear();
+        self.rmac_key.clear();
+    }
+}
+
+/// Derive a key using the SCP03 cryptogram protocol
+fn derive_key(
+    parent_key: &[u8; KEY_SIZE],
+    derivation_constant: u8,
+    context: &Context,
+) -> [u8; KEY_SIZE] {
+    let mut key = [0u8; KEY_SIZE];
+    cryptogram::calculate(parent_key, derivation_constant, context, &mut key);
+    key
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 extern crate failure;
 extern crate reqwest;
+extern crate scp03;
 
 #[macro_use]
 extern crate failure_derive;


### PR DESCRIPTION
This protocol is used for encrypted sessions between host clients and the YubiHSM2.