### PR TITLE
Add err! and fail! macros to clean up error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,25 @@ extern crate rand;
 extern crate reqwest;
 extern crate sha2;
 
+/// Custom error macros for using enums with descriptions for errors
+macro_rules! err {
+    ($errtype:ident::$variant:ident, $msg:expr) => {
+        $errtype::$variant { description: $msg.to_owned() }
+    };
+    ($errtype:ident::$variant:ident, $fmt:expr, $($arg:tt)+) => {
+        $errtype::$variant { description: format!($fmt, $($arg)+) }
+    };
+}
+
+macro_rules! fail {
+    ($errtype:ident::$variant:ident, $msg:expr) => {
+        return Err(err!($errtype::$variant, $msg).into());
+    };
+    ($errtype:ident::$variant:ident, $fmt:expr, $($arg:tt)+) => {
+        return Err(err!($errtype::$variant, $fmt, $($arg)+).into());
+    };
+}
+
 pub mod connector;
 #[cfg(any(feature = "mockhsm"))]
 pub mod mockhsm;

--- a/src/securechannel/error.rs
+++ b/src/securechannel/error.rs
@@ -5,7 +5,7 @@
 pub enum SecureChannelError {
     /// MAC or cryptogram verify failed
     #[cfg(feature = "mockhsm")]
-    #[fail(display = "couldn't create session: {}", description)]
+    #[fail(display = "verification failed: {}", description)]
     VerifyFailed {
         /// Description of the verification failure
         description: String,

--- a/src/securechannel/mac.rs
+++ b/src/securechannel/mac.rs
@@ -52,9 +52,7 @@ impl Mac {
         let crypto_mac_code = crypto_mac.code();
 
         if !constant_time_eq(&self.0, &crypto_mac_code.as_slice()[..MAC_SIZE]) {
-            Err(SecureChannelError::VerifyFailed {
-                description: "MAC verification failure!".to_owned(),
-            })?;
+            fail!(SecureChannelError::VerifyFailed, "MAC mismatch!");
         }
 
         chaining_value.copy_from_slice(crypto_mac_code.as_slice());


### PR DESCRIPTION
After this change, it really seems like this crate should really be using `failure::Error`'s `context` field for the descriptions, and the enums representing different `ErrorKinds`.

Using a macro for constructing errors should at least permit this kind of refactoring.