### PR TITLE
Remove unnecessary #![allow(dead_code, missing_docs)] directives

### DIFF
--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -45,7 +45,6 @@ impl Id {
 pub const MAX_SESSION_ID: Id = Id(16);
 
 /// Current Security Level: protocol state
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SecurityLevel {
     /// 'NO_SECURITY_LEVEL' i.e. session is terminated or not fully initialized
@@ -56,7 +55,6 @@ pub enum SecurityLevel {
 }
 
 /// SCP03 Secure Channel
-#[allow(dead_code)]
 pub(crate) struct Channel {
     // ID of this channel (a.k.a. session ID)
     id: Id,

--- a/src/securechannel/command.rs
+++ b/src/securechannel/command.rs
@@ -12,7 +12,6 @@ use super::{Mac, SecureChannelError, SessionId, MAC_SIZE};
 
 /// A command sent from the host to the `YubiHSM2`. May or may not be
 /// authenticated using SCP03's chained/evolving MAC protocol.
-#[allow(dead_code)]
 pub(crate) struct Command {
     /// Type of command to be invoked
     pub command_type: CommandType,
@@ -146,7 +145,6 @@ impl Command {
 }
 
 /// Command IDs for `YubiHSM2` operations
-#[allow(dead_code, missing_docs)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum CommandType {
     Unknown = 0x00,
@@ -357,7 +355,6 @@ impl Response {
 }
 
 /// Codes associated with `YubiHSM2` responses
-#[allow(dead_code, missing_docs)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ResponseCode {
     Success(CommandType),


### PR DESCRIPTION
These are no longer needed