### PR TITLE
Track and bound number of messages per session

### DIFF
--- a/src/securechannel/error.rs
+++ b/src/securechannel/error.rs
@@ -17,4 +17,11 @@ pub enum SecureChannelError {
         /// Description of the protocol error
         description: String,
     },
+
+    /// Max commands per session exceeded and a new session should be created
+    #[fail(display = "session limit reached: {}", description)]
+    SessionLimitReached {
+        /// Description of the protocol error
+        description: String,
+    },
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -89,7 +89,8 @@ impl<'a> Session<'a> {
 
     /// Authenticate the current session with the `YubiHSM2`
     fn authenticate(&mut self) -> Result<(), Error> {
-        let response = self.connector.command(self.channel.authenticate_session())?;
+        let command = self.channel.authenticate_session()?;
+        let response = self.connector.command(command)?;
         self.channel.finish_authenticate_session(&response)
     }
 


### PR DESCRIPTION
The SCP03 protocol uses a small MAC size: 8-bytes.

To avoid collisions, this bounds the maximum number of commands that can be sent in one session to 1,048,576 (i.e. 2^20), and forces creation of a fresh session after that number of commands has been sent.