### PR TITLE
Encrypted session messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords    = ["cryptography", "encryption", "security"]
 
 [dependencies]
 aesni = "0.2"
+block-modes = { git = "https://github.com/RustCrypto/block-ciphers.git" }
 byteorder = "1.2"
 clear_on_drop = "0.2"
 cmac = "0.1"

--- a/README.md
+++ b/README.md
@@ -22,39 +22,67 @@ interface to [YubiHSM2] devices from [Yubico].
 
 ## About
 
-This library attempts to reimplement some of the functionality of **libyubihsm**,
-a closed-source C library which acts as a libcurl-based HTTP(S) client and sends
-commands to the [yubihsm-connector] process, which implements an HTTP(S) server
-which sends the commands to the YubiHSM2 hardware device over USB. However,
+This is a pure-Rust crate for interfacing with YubiHSM2 devices.
+
+It presently reimplements a small subset of the of the functionality of
+**libyubihsm**, a closed-source C library which acts as a libcurl-based HTTP(S)
+client and sends commands to the [yubihsm-connector] process, which implements
+an HTTP(S) server which sends the commands to the YubiHSM2 hardware device over USB.
+
 **libyubihsm** can be difficult to work with because it is shipped as a
 platform-specific dynamic library which needs its own special versions of
 libcurl and OpenSSL.
 
 **yubihsm-client** is a pure-Rust reimplementation of a similar HTTP(S) client
 library for **yubihsm-connector** based on documentation provided by Yubico.
-Only a small amount of the functionality provided by **libyubihsm** has been
-reimplemented.
+It implements an encrypted connection to the YubiHSM2 using
+[GlobalPlatform Secure Channel Protocol "03"] implemented using AES crates
+from the [RustCrypto GitHub Organization].
 
-**yubihsm-client** is implemented using the [reqwest] Rust HTTP client library.
+The [reqwest] crate is used to make HTTP(S) requests to **yubihsm-connector**.
 
 [yubihsm-connector]: https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/
+[GlobalPlatform Secure Channel Protocol "03"]: https://www.globalplatform.org/specificationscard.asp
+[RustCrypto GitHub Organization]: https://github.com/RustCrypto
 [reqwest]: https://github.com/seanmonstar/reqwest
 
 ## Status
 
-Not ready. Nascent. Do not attempt to use.
+Currently working:
+
+* Creating encrypted sessions with YubiHSM2
+* Authenticating to YubiHSM2
+* The [Echo Command], which you can use to send "Hello, world!"
+
+Not working:
+
+* Anything actually useful
+
+[Echo Command]: https://developers.yubico.com/YubiHSM2/Commands/Echo.html
 
 ## Testing
 
-Tests for **yubihsm-client** assume you have a YubiHSM2 hardware device, have
-downloaded the [YubiHSM2 SDK] for your platform, and are running a
-**yubihsm-connector** process listening on localhost on the default port of 12345.
+This crate allows you to run the integration test suite in two different ways:
+live testing against a real YubiHSM2 device, and simulated testing using
+a MockHSM service which reimplements some YubiHSM2 functionality in software.
+
+### `cargo test`: test live against a YubiHSM2 device
+
+This mode assumes you have a YubiHSM2 hardware device, have downloaded the
+[YubiHSM2 SDK] for your platform, and are running a **yubihsm-connector**
+process listening on localhost on the default port of 12345.
+
 The YubiHSM2 device should be in the default factory state. To reset it to this
 state, either use the [yubihsm-shell reset] command or press on the YubiHSM2 for
 10 seconds immediately after inserting it.
 
 [YubiHSM2 SDK]: https://developers.yubico.com/YubiHSM2/Releases/
 [yubihsm-shell reset]: https://developers.yubico.com/YubiHSM2/Commands/Reset.html
+
+### `cargo test --features=mockhsm`: simulated tests against a mock HSM
+
+This mode is useful for when you don't have access to physical YubiHSM2
+hardware, such as CI environments.
 
 ## License
 

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -179,7 +179,7 @@ impl Connector {
     }
 
     /// POST /connector/api with a given command message
-    pub(crate) fn command(&self, cmd: Command) -> Result<Response, Error> {
+    pub(crate) fn send_command(&self, cmd: Command) -> Result<Response, Error> {
         let cmd_type = cmd.command_type;
         let response_bytes = self.post("/connector/api", cmd.into_vec())?;
         let response = Response::parse(response_bytes)?;
@@ -188,7 +188,7 @@ impl Connector {
             fail!(
                 ConnectorError::ResponseError,
                 "Error response code from HSM: {:?}",
-                response.code()
+                response.code
             );
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 
 extern crate aesni;
+extern crate block_modes;
 extern crate byteorder;
 extern crate clear_on_drop;
 extern crate cmac;
@@ -47,6 +48,7 @@ pub mod session;
 
 pub use connector::Connector;
 pub use securechannel::SessionId;
+pub use session::{Session, SessionError};
 
 /// Key identifiers
 pub type KeyId = u16;

--- a/src/securechannel/error.rs
+++ b/src/securechannel/error.rs
@@ -4,7 +4,6 @@
 #[derive(Debug, Fail)]
 pub enum SecureChannelError {
     /// MAC or cryptogram verify failed
-    #[cfg(feature = "mockhsm")]
     #[fail(display = "verification failed: {}", description)]
     VerifyFailed {
         /// Description of the verification failure

--- a/src/securechannel/mod.rs
+++ b/src/securechannel/mod.rs
@@ -25,6 +25,7 @@ mod cryptogram;
 mod error;
 mod kdf;
 mod mac;
+mod response;
 mod static_keys;
 
 /// AES key size in bytes. SCP03 theoretically supports other key sizes, but
@@ -36,9 +37,12 @@ pub use self::challenge::{Challenge, CHALLENGE_SIZE};
 pub(crate) use self::channel::Channel;
 pub use self::channel::Id as SessionId;
 pub(crate) use self::command::Command;
-pub use self::command::{CommandType, Response, ResponseCode};
+pub use self::command::CommandType;
 pub use self::context::{Context, CONTEXT_SIZE};
 pub use self::cryptogram::{Cryptogram, CRYPTOGRAM_SIZE};
 pub use self::error::SecureChannelError;
 pub(crate) use self::mac::{Mac, MAC_SIZE};
+pub(crate) use self::response::Response;
+#[cfg(feature = "mockhsm")]
+pub(crate) use self::response::ResponseCode;
 pub use self::static_keys::StaticKeys;

--- a/src/securechannel/response.rs
+++ b/src/securechannel/response.rs
@@ -1,0 +1,329 @@
+//! Responses sent back from the YubiHSM2
+
+use byteorder::{BigEndian, ByteOrder};
+#[cfg(feature = "mockhsm")]
+use byteorder::WriteBytesExt;
+use failure::Error;
+use super::{CommandType, Mac, SecureChannelError, SessionId, MAC_SIZE};
+
+/// Command responses
+#[derive(Debug, Eq, PartialEq)]
+pub struct Response {
+    /// Success (for a given command type) or an error type
+    pub code: ResponseCode,
+
+    /// Session ID for this response
+    pub session_id: Option<SessionId>,
+
+    /// "Response Data Field"
+    pub data: Vec<u8>,
+
+    /// Optional Message Authentication Code (MAC)
+    pub mac: Option<Mac>,
+}
+
+impl Response {
+    /// Parse a response into a Response struct
+    pub fn parse(mut bytes: Vec<u8>) -> Result<Self, Error> {
+        if bytes.len() < 3 {
+            fail!(
+                SecureChannelError::ProtocolError,
+                "response too short: {} (expected at least 3-bytes)",
+                bytes.len()
+            );
+        }
+
+        let code = ResponseCode::from_u8(bytes[0])?;
+        let length = BigEndian::read_u16(&bytes[1..3]) as usize;
+
+        if length + 3 != bytes.len() {
+            fail!(
+                SecureChannelError::ProtocolError,
+                "unexpected response length {} (expecting {})",
+                bytes.len() - 3,
+                length
+            );
+        }
+
+        bytes.drain(..3);
+
+        let session_id = if code.has_session_id() {
+            if bytes.is_empty() {
+                fail!(
+                    SecureChannelError::ProtocolError,
+                    "expected session ID but response data is empty"
+                );
+            }
+
+            Some(SessionId::new(bytes.remove(0))?)
+        } else {
+            None
+        };
+
+        let mac = if code.has_rmac() {
+            if bytes.len() < MAC_SIZE {
+                fail!(
+                    SecureChannelError::ProtocolError,
+                    "expected R-MAC for {:?} but response data is too short: {}",
+                    code,
+                    bytes.len(),
+                );
+            }
+
+            let mac_index = bytes.len() - MAC_SIZE;
+            Some(Mac::from_slice(&bytes.split_off(mac_index)))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            code,
+            session_id,
+            data: bytes,
+            mac,
+        })
+    }
+
+    /// Create a new response without an associated session
+    #[cfg(feature = "mockhsm")]
+    pub fn new<T>(code: ResponseCode, response_data: T) -> Response
+    where
+        T: Into<Vec<u8>>,
+    {
+        Response {
+            code,
+            session_id: None,
+            data: response_data.into(),
+            mac: None,
+        }
+    }
+
+    /// Create a new response message with a MAC
+    #[cfg(feature = "mockhsm")]
+    pub fn new_with_mac<D, M>(
+        code: ResponseCode,
+        session_id: SessionId,
+        response_data: D,
+        mac: M,
+    ) -> Self
+    where
+        D: Into<Vec<u8>>,
+        M: Into<Mac>,
+    {
+        Self {
+            code,
+            session_id: Some(session_id),
+            data: response_data.into(),
+            mac: Some(mac.into()),
+        }
+    }
+
+    /// Create a successful response
+    #[cfg(feature = "mockhsm")]
+    pub fn success<T>(command_type: CommandType, response_data: T) -> Response
+    where
+        T: Into<Vec<u8>>,
+    {
+        Self::new(ResponseCode::Success(command_type), response_data)
+    }
+
+    /// Was this command successful?
+    pub fn is_ok(&self) -> bool {
+        match self.code {
+            ResponseCode::Success(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Did an error occur?
+    pub fn is_err(&self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Get the command being responded to
+    pub fn command(&self) -> Option<CommandType> {
+        match self.code {
+            ResponseCode::Success(cmd) => Some(cmd),
+            _ => None,
+        }
+    }
+
+    /// Total length of the response
+    pub fn len(&self) -> usize {
+        let mut result = self.data.len();
+
+        if self.session_id.is_some() {
+            result += 1;
+        }
+
+        if self.mac.is_some() {
+            result += MAC_SIZE;
+        }
+
+        result
+    }
+
+    /// Serialize this response, consuming it and producing a Vec<u8>
+    #[cfg(feature = "mockhsm")]
+    pub fn into_vec(mut self) -> Vec<u8> {
+        let mut result = Vec::with_capacity(3 + self.len());
+        result.push(self.code.to_u8());
+        result.write_u16::<BigEndian>(self.len() as u16).unwrap();
+
+        if let Some(session_id) = self.session_id {
+            result.push(session_id.to_u8());
+        }
+
+        result.append(&mut self.data);
+
+        if let Some(mac) = self.mac {
+            result.extend_from_slice(mac.as_slice());
+        }
+
+        result
+    }
+}
+
+/// Codes associated with `YubiHSM2` responses
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ResponseCode {
+    Success(CommandType),
+    MemoryError,
+    InitError,
+    NetError,
+    ConnectorNotFound,
+    InvalidParams,
+    WrongLength,
+    BufferTooSmall,
+    CryptogramMismatch,
+    AuthSessionError,
+    MACMismatch,
+    DeviceOK,
+    DeviceInvalidCommand,
+    DeviceInvalidData,
+    DeviceInvalidSession,
+    DeviceAuthFail,
+    DeviceSessionsFull,
+    DeviceSessionFailed,
+    DeviceStorageFailed,
+    DeviceWrongLength,
+    DeviceInvalidPermission,
+    DeviceLogFull,
+    DeviceObjNotFound,
+    DeviceIDIllegal,
+    DeviceInvalidOTP,
+    DeviceDemoMode,
+    DeviceCmdUnexecuted,
+    GenericError,
+    DeviceObjectExists,
+    ConnectorError,
+}
+
+impl ResponseCode {
+    /// Convert an unsigned byte into a ResponseCode (if valid)
+    pub fn from_u8(byte: u8) -> Result<Self, Error> {
+        let code = (i16::from(byte) - 0x80) as i8;
+
+        if code >= 0 {
+            let command_type = CommandType::from_u8(code as u8)?;
+            return Ok(ResponseCode::Success(command_type));
+        }
+
+        Ok(match code {
+            -1 => ResponseCode::MemoryError,
+            -2 => ResponseCode::InitError,
+            -3 => ResponseCode::NetError,
+            -4 => ResponseCode::ConnectorNotFound,
+            -5 => ResponseCode::InvalidParams,
+            -6 => ResponseCode::WrongLength,
+            -7 => ResponseCode::BufferTooSmall,
+            -8 => ResponseCode::CryptogramMismatch,
+            -9 => ResponseCode::AuthSessionError,
+            -10 => ResponseCode::MACMismatch,
+            -11 => ResponseCode::DeviceOK,
+            -12 => ResponseCode::DeviceInvalidCommand,
+            -13 => ResponseCode::DeviceInvalidData,
+            -14 => ResponseCode::DeviceInvalidSession,
+            -15 => ResponseCode::DeviceAuthFail,
+            -16 => ResponseCode::DeviceSessionsFull,
+            -17 => ResponseCode::DeviceSessionFailed,
+            -18 => ResponseCode::DeviceStorageFailed,
+            -19 => ResponseCode::DeviceWrongLength,
+            -20 => ResponseCode::DeviceInvalidPermission,
+            -21 => ResponseCode::DeviceLogFull,
+            -22 => ResponseCode::DeviceObjNotFound,
+            -23 => ResponseCode::DeviceIDIllegal,
+            -24 => ResponseCode::DeviceInvalidOTP,
+            -25 => ResponseCode::DeviceDemoMode,
+            -26 => ResponseCode::DeviceCmdUnexecuted,
+            -27 => ResponseCode::GenericError,
+            -28 => ResponseCode::DeviceObjectExists,
+            -29 => ResponseCode::ConnectorError,
+            _ => fail!(
+                SecureChannelError::ProtocolError,
+                "invalid response code: {}",
+                code
+            ),
+        })
+    }
+
+    /// Convert a ResponseCode back into its original byte form
+    pub fn to_u8(&self) -> u8 {
+        let code: i8 = match *self {
+            ResponseCode::Success(cmd_type) => cmd_type as i8,
+            ResponseCode::MemoryError => -1,
+            ResponseCode::InitError => -2,
+            ResponseCode::NetError => -3,
+            ResponseCode::ConnectorNotFound => -4,
+            ResponseCode::InvalidParams => -5,
+            ResponseCode::WrongLength => -6,
+            ResponseCode::BufferTooSmall => -7,
+            ResponseCode::CryptogramMismatch => -8,
+            ResponseCode::AuthSessionError => -9,
+            ResponseCode::MACMismatch => -10,
+            ResponseCode::DeviceOK => -11,
+            ResponseCode::DeviceInvalidCommand => -12,
+            ResponseCode::DeviceInvalidData => -13,
+            ResponseCode::DeviceInvalidSession => -14,
+            ResponseCode::DeviceAuthFail => -15,
+            ResponseCode::DeviceSessionsFull => -16,
+            ResponseCode::DeviceSessionFailed => -17,
+            ResponseCode::DeviceStorageFailed => -18,
+            ResponseCode::DeviceWrongLength => -19,
+            ResponseCode::DeviceInvalidPermission => -20,
+            ResponseCode::DeviceLogFull => -21,
+            ResponseCode::DeviceObjNotFound => -22,
+            ResponseCode::DeviceIDIllegal => -23,
+            ResponseCode::DeviceInvalidOTP => -24,
+            ResponseCode::DeviceDemoMode => -25,
+            ResponseCode::DeviceCmdUnexecuted => -26,
+            ResponseCode::GenericError => -27,
+            ResponseCode::DeviceObjectExists => -28,
+            ResponseCode::ConnectorError => -29,
+        };
+
+        (i16::from(code) + 0x80) as u8
+    }
+
+    /// Does this response include a session ID?
+    pub fn has_session_id(&self) -> bool {
+        match *self {
+            ResponseCode::Success(cmd_type) => match cmd_type {
+                CommandType::CreateSession | CommandType::SessionMessage => true,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    /// Does this response have a Response-MAC (C-MAC) value on the end?
+    pub fn has_rmac(&self) -> bool {
+        match *self {
+            ResponseCode::Success(cmd_type) => match cmd_type {
+                CommandType::SessionMessage => true,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,12 +1,18 @@
 extern crate yubihsm_client;
 
+#[cfg(feature = "mockhsm")]
 use std::thread;
 
-use yubihsm_client::{Connector, KeyId, SessionId};
+use yubihsm_client::{Connector, KeyId, Session, SessionId};
 #[cfg(feature = "mockhsm")]
 use yubihsm_client::mockhsm::MockHSM;
 
+/// Test against the real yubihsm-connector
+#[cfg(not(feature = "mockhsm"))]
+const YUBIHSM_ADDR: &str = "127.0.0.1:12345";
+
 // TODO: pick an open port automatically
+#[cfg(feature = "mockhsm")]
 const MOCKHSM_ADDR: &str = "127.0.0.1:54321";
 
 /// Default auth key ID slot
@@ -14,6 +20,19 @@ const DEFAULT_AUTH_KEY_ID: KeyId = 1;
 
 /// Default password
 const DEFAULT_PASSWORD: &str = "password";
+
+#[cfg(not(feature = "mockhsm"))]
+#[test]
+fn yubihsm_integration_test() {
+    let conn = Connector::open(&format!("http://{}", YUBIHSM_ADDR))
+        .unwrap_or_else(|err| panic!("cannot open connection to yubihsm-connector: {:?}", err));
+
+    let mut session = conn.create_session_from_password(DEFAULT_AUTH_KEY_ID, DEFAULT_PASSWORD)
+        .unwrap_or_else(|err| panic!("error creating session: {:?}", err));
+
+    assert_eq!(session.id(), SessionId::new(0).unwrap());
+    echo_test(&mut session);
+}
 
 #[cfg(feature = "mockhsm")]
 fn start_mockhsm(num_requests: usize) -> thread::JoinHandle<()> {
@@ -23,22 +42,27 @@ fn start_mockhsm(num_requests: usize) -> thread::JoinHandle<()> {
 #[cfg(feature = "mockhsm")]
 #[test]
 fn mockhsm_integration_test() {
-    let num_requests = 3;
+    let num_requests = 4;
     let mockhsm_thread = start_mockhsm(num_requests);
 
     let conn = Connector::open(&format!("http://{}", MOCKHSM_ADDR))
-        .unwrap_or_else(|err| panic!("cannot open connection to yubihsm-connector: {:?}", err));
+        .unwrap_or_else(|err| panic!("cannot open connection to mockhsm: {:?}", err));
 
-    let session = conn.create_session_from_password(DEFAULT_AUTH_KEY_ID, DEFAULT_PASSWORD)
+    let mut session = conn.create_session_from_password(DEFAULT_AUTH_KEY_ID, DEFAULT_PASSWORD)
         .unwrap_or_else(|err| panic!("error creating session: {:?}", err));
 
     assert_eq!(session.id(), SessionId::new(0).unwrap());
+    echo_test(&mut session);
 
     mockhsm_thread.join().unwrap();
 }
 
-#[cfg(not(feature = "mockhsm"))]
-#[test]
-fn panic_unless_mockhsm_is_available() {
-    panic!("run tests with 'cargo test --features=mockhsm'")
+// Send a simple echo request
+fn echo_test(session: &mut Session) {
+    let message = b"Hello, world!";
+    let echo_result = session
+        .echo(message)
+        .unwrap_or_else(|err| panic!("error sending echo: {:?}", err));
+
+    assert_eq!(&message[..], &echo_result[..]);
 }


### PR DESCRIPTION
Support for encrypting messages sent to the YubiHSM, as well as verifying their R-MAC and decrypting the responses.

Additionally adds support to MockHSM to decrypt incoming commands and encrypt responses.